### PR TITLE
workaround to setup flask virtual env

### DIFF
--- a/roles/flask/tasks/main.yml
+++ b/roles/flask/tasks/main.yml
@@ -54,6 +54,7 @@
         virtualenv: "{{ virtualenv_home }}/{{ flask_app_name }}"
         virtualenv_site_packages: no
         virtualenv_command: /usr/local/bin/virtualenv
+        virtualenv_python: /usr/bin/python3.8
   tags:
     - venv
     - virtualenv  


### PR DESCRIPTION
By default the role uses /usr/libexec/platform-python in app01/02 to install venv and the dependencies inside. This does not work: some future feature is missing. According my diging it is baceouse the default platform-python is 3.6 So explicitly pointing the python to 3.8 works around